### PR TITLE
Using openjdk and Java 8 Update 121

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:7u65
+FROM openjdk:8u121
 MAINTAINER Lu Han <lhan@xetus.com>
 
 ENV VERSION 2.2.1


### PR DESCRIPTION
Hi! I tried building and running the docker image with the newest openjdk 8u121 and it worked for me (I didn't test everything to be honest). There will be absolutely no public updates for Java 7 after 17th of September 2017. In addition the deprecated Java docker image should no longer be used, but the openjdk image instead.