### PR TITLE
A set of tweaks, mainly supporting the new `-XX:+UseContainerSupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Apache Archiva image for simple standalone deployments.
 
 | Tag                                                                                        | Description                           |
 |--------------------------------------------------------------------------------------------|---------------------------------------|
-|[`v2`,`v2.2.4`, `latest`](https://github.com/xetus-oss/docker-archiva/blob/v2/Dockerfile)   | Tracks the latest version of Archiva  |
+|[`v2`,`v2.2.4-1`, `latest`](https://github.com/xetus-oss/docker-archiva/blob/v2/Dockerfile) | Tracks the latest version of Archiva  |
 |[`v2-snapshot`](https://github.com/xetus-oss/docker-archiva/blob/v2-snapshot/Dockerfile)    | Tracks v2 snapshot builds for Archiva |
 |[`2.2.3`,`v2-legacy`](https://github.com/xetus-oss/docker-archiva/blob/v2-legacy/Dockerfile)| Legacy versions of this image         |
 
@@ -98,9 +98,9 @@ The archiva user database can be stored in `mysql` instead of `derby` (the defau
 
 See the [docker-compose.mysql.yaml](docker-compose.mysql.yaml) for a complete example of using MySQL.
 
-## `JVM_MAX_MEM`, `JVM_EXTRA_OPTS`
+## `JVM_EXTRA_OPTS`, `MALLOC_ARENA_MAX`
 
-These properties allow fine-tuned control over the JVM environment that archiva runs in. Unless you have specific needs, neither of these need to set.
+Allow fine-tuned control over the JVM environment that archiva runs in, or set the MALLOC_ARENA_MAX. Unless you have specific needs, neither of these need to be set.
 
 ## `JETTY_CONFIG_PATH`
 
@@ -120,6 +120,16 @@ The Archiva project is not dead, but it's development is (very) slow. A reasonab
 4. It has this great docker image :-).
 
 # Change Log
+
+## `V2.2.4-1`
+
+Resource configuration improvements from our experience running Archiva in k8s. Still using Archiva `v2.2.4`.
+
+-   _Use `-XX:+UseContainerSupport`, retire `JVM_MAX_MEM`_
+    Java 8u191 includes [improved support for docker containers](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8146115). This allows the java process to respect the container limits set by `cgroups`. Before this feature, the JVM would allocate resources for itself based on the host's total resources instead of the resources allocated to the container. The only way to avoid the situation was to set a series of related and complicated JVM options. With the improved container support, simply setting the container's resource limits is all that's needed. Due to this, we also retired support for the `JVM_MAX_MEM` enviroment variable. If specific tuning is required, users should use `JVM_EXTRA_OPTS`. 
+
+-   _Set default `MALLOC_ARENA_MAX`_
+    We now automatically export MALLOC_ARENA_MAX=2, unless specified by the user. Setting this option avoids the rare case of the jvm exceeding the container's memory limits.
 
 ## `V2.2.4`
 

--- a/docker-compose.cacerts.yaml
+++ b/docker-compose.cacerts.yaml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '2.4'
 services:
   #
   # The primary archiva service
@@ -15,6 +15,8 @@ services:
       - ./cacerts-test:/certs
     networks:
       - container
+    cpus: 2.0
+    mem_limit: 512m
 
 networks:
   container:

--- a/docker-compose.mysql.yaml
+++ b/docker-compose.mysql.yaml
@@ -1,7 +1,7 @@
 #
 # * This is an override to the default docker-compose.yaml file
 #
-version: '3.4'
+version: '2.4'
 services:
   #
   # Test a a specific archiva image.

--- a/docker-compose.nginx-https.yaml
+++ b/docker-compose.nginx-https.yaml
@@ -1,7 +1,7 @@
 #
 # * This is an override to the default docker-compose.yaml file
 #
-version: '3.4'
+version: '2.4'
 services:
   #
   # Test a a specific archiva image.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '2.4'
 services:
   #
   # The primary archiva service
@@ -16,7 +16,9 @@ services:
     environment:
       SMTP_HOST: smtp
       SMTP_PORT: 1025
-  #
+    cpus: 2.0
+    mem_limit: 512m
+    #
   # Used for validating mail is sent as expected
   #
   smtp:

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -11,9 +11,15 @@ then
   echo "WARNING: SMTP_HOST not set, Archiva cannot send emails!" > /dev/stderr
 fi
 
-JVM_MAX_MEM=${JVM_MAX_MEM:-512}
+if [ -e $JVM_MAX_MEM ]
+then
+  echo "WARNING: JVM_MAX_MEM has been depreciated and is no longer used!"
+fi
+
 DB_TYPE=${DB_TYPE:-derby}
 JETTY_CONFIG_PATH=${JETTY_CONFIG_PATH:-/tmp/jetty.xml}
+# A preventative measure to avoid OOM errors
+MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-2}
 
 #
 # Initialize the volume data directories
@@ -97,8 +103,7 @@ JVM_OPTS=(
   "-Djava.io.tmpdir=${ARCHIVA_BASE}/temp"
   "-DAsyncLoggerConfig.WaitStrategy=Block"
   "-Darchiva.repositorySessionFactory.id=jcr"
-  "-Xmx${JVM_MAX_MEM}m"
-  "-Xms${JVM_MAX_MEM}m"
+  "-XX:+UseContainerSupport"
 )
 
 #

--- a/resource-retriever.sh
+++ b/resource-retriever.sh
@@ -27,7 +27,7 @@ fi
 #
 # Archiva binary parameters
 #
-ARCHIVA_RELEASE_URL=${ARCHIVA_RELEASE_URL:-https://www-us.apache.org/dist/archiva/2.2.4/binaries/apache-archiva-2.2.4-bin.tar.gz}
+ARCHIVA_RELEASE_URL=${ARCHIVA_RELEASE_URL:-https://downloads.apache.org/archiva/2.2.4/binaries/apache-archiva-2.2.4-bin.tar.gz}
 ARCHIVA_RELEASE_MD5SUM=${ARCHIVA_RELEASE_MD5SUM:-597aeb9f42e634ae58256fb99997040f}
 
 #


### PR DESCRIPTION
Based on our experience running this image in k8s, a few changes to avoid over-consumption of resources (specifically memory)

Main changes:

1. Add the `-XX:+UseContainerSupport` argument to the java command, this avoids the common scenario where the JVM would consume more memory than allocated to it through `cgroups`.
2. Remove support for the `JVM_MAX_MEM` environment variable. Since Java 8u191, it's much better to use the native `UseContainerSupport` feature. For folks that want to granularly manage the heap, they can use `JVM_EXTRA_OPTS`

Related changes:

1. Added a changelog for this feature, assuming this will go out as `v2.2.4-1`
2. Moved to using docker-compose v2. This is required for testing, since docker-compose v3 [doesn't support memory limits/cpu limits in v3](https://github.com/docker/compose/issues/4513).
3. Updated the archiva download URL, since the old FQDN is no longer working.