### PR TITLE
Rebase to Eclipse Temurin docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 MAINTAINER Xetus OSS <xetusoss@xetus.com>
 
 # Add the archiva user and group with a specific UID/GUI to ensure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: Dockerfile
       cache_from: 
-        - openjdk:8-jdk-alpine
+        - eclipse-temurin:8-jdk-alpine
         - xetusoss/archiva:latest
         - xetusoss/archiva:v2
       args:

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -77,13 +77,13 @@ then
     # First, delete the entry, if it exsits
     set +e
     keytool -delete -alias "$CERT_ALIAS"\
-       -keystore /etc/ssl/certs/java/cacerts\
+       -keystore "${JAVA_HOME}/jre/lib/security/cacerts"\
        -storepass changeit\
        -noprompt > /dev/null 2>&1
     set -e
 
     keytool -import -trustcacerts -alias "$CERT_ALIAS"\
-      -keystore /etc/ssl/certs/java/cacerts\
+      -keystore "${JAVA_HOME}/jre/lib/security/cacerts"\
       -file "$certfile"\
       -storepass changeit\
       -noprompt

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -53,5 +53,5 @@ chown -R archiva:archiva $ARCHIVA_BASE $TEMPLATE_ROOT
 # Make the cacerts owned by archiva so we can add
 # certs to it, if necessary
 #
-chown archiva:archiva /etc/ssl/certs/java/cacerts
-chmod u+w /etc/ssl/certs/java/cacerts
+chown archiva:archiva ${JAVA_HOME}/jre/lib/security/cacerts
+chmod u+w ${JAVA_HOME}/jre/lib/security/cacerts

--- a/local-tests.sh
+++ b/local-tests.sh
@@ -188,7 +188,7 @@ then
     CERT_LIST="$(docker-compose exec archiva keytool \
       -list -v -storepass 'changeit'\
       --noprompt \
-      -keystore /etc/ssl/certs/java/cacerts)"
+      -keystore /opt/java/openjdk/jre/lib/security/cacerts)"
     if (( $? != 0 ))
     then
       printError "Could not list installed cacerts, cannot complete test"


### PR DESCRIPTION
The `openjdk:8-jdk-alpine` docker image is 3 years old and is not maintained.

See this notice:
https://github.com/docker-library/docs/blob/master/openjdk/README.md#openjdkversion-alpine

and quoting directly:

> The OpenJDK port for Alpine is not in a supported release by OpenJDK, since it is not in the mainline code base. It is only available as early access builds of [OpenJDK Project Portola](http://openjdk.java.net/projects/portola). See also https://github.com/docker-library/openjdk/pull/235#issuecomment-424599754. So this image follows what is available from the OpenJDK project's maintainers.

> What this means is that Alpine based images are only released for early access release versions of OpenJDK. Once a particular release becomes a "General-Availability" release, the Alpine version is dropped from the "Supported Tags"; they are still available to pull, but will no longer be updated.

I recommended migrating to Eclipse Temurin as they support Alpine and maintain their `8-jdk-alpine` equivalent docker tag.
See here:
https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#eclipse-temurinversion-alpine

Eclipse Temurin make no reservations against Alpine, and their docker image is maintained and supported (and was updated 12 days ago at time of writing) and contains the latest update of Java 8u332 (instead of 8u212 provided by `openjdk:8-jdk-alpine`)


I ran `make test` and everything passed successfully. The location of the `cacerts` file has changed with this migration, so the respective references were updated.