### PR TITLE
Updated version to 2.2.9 and snapshot to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## `V2.2.9`
+
+Updated to Archiva `v2.2.9` which includes several security fixes. See [archiva release notes](https://archiva.apache.org/docs/2.2.9/release-notes.html).
+
+Updated snapshot to 3.0.0.
+
 ## `V2.2.8-1`
 
 Swap the openjdk 8 alpine base image the Eclipse Temurin one. See [PR#34](https://github.com/xetus-oss/docker-archiva/pull/34) for more information. Thanks @mattmatician!
@@ -25,7 +31,7 @@ Updated to Archiva `v2.2.5` which includes a fix for [CVE-2020-9495](https://www
 Resource configuration improvements from our experience running Archiva in k8s. Still using Archiva `v2.2.4`.
 
 -   __Use `-XX:+UseContainerSupport`, retire `JVM_MAX_MEM`__
-    Java 8u191 includes [improved support for docker containers](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8146115). This allows the java process to respect the container limits set by `cgroups`. Before this feature, the JVM would allocate resources for itself based on the host's total resources instead of the resources allocated to the container. The only way to avoid the situation was to set a series of related and complicated JVM options. With the improved container support, simply setting the container's resource limits is all that's needed. Due to this, we also retired support for the `JVM_MAX_MEM` environment variable. If specific tuning is required, users should use `JVM_EXTRA_OPTS`. 
+    Java 8u191 includes [improved support for docker containers](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8146115). This allows the java process to respect the container limits set by `cgroups`. Before this feature, the JVM would allocate resources for itself based on the host's total resources instead of the resources allocated to the container. The only way to avoid the situation was to set a series of related and complicated JVM options. With the improved container support, simply setting the container's resource limits is all that's needed. Due to this, we also retired support for the `JVM_MAX_MEM` environment variable. If specific tuning is required, users should use `JVM_EXTRA_OPTS`.
 
 -   __Set default `MALLOC_ARENA_MAX`__
     We now automatically export MALLOC_ARENA_MAX=2, unless specified by the user. Setting this option avoids the rare case of the jvm exceeding the container's memory limits.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Apache Archiva image for simple standalone deployments.
 
 | Tag                                                                                        | Description                           |
 |--------------------------------------------------------------------------------------------|---------------------------------------|
-|[`v2`,`v2.2.8-1`, `latest`](https://github.com/xetus-oss/docker-archiva/blob/v2/Dockerfile)   | Tracks the latest version of Archiva  |
+|[`v2`,`v2.2.9`, `latest`](https://github.com/xetus-oss/docker-archiva/blob/v2/Dockerfile)   | Tracks the latest version of Archiva  |
 |[`v2-snapshot`](https://github.com/xetus-oss/docker-archiva/blob/v2-snapshot/Dockerfile)    | Tracks v2 snapshot builds for Archiva |
 |[`2.2.3`,`v2-legacy`](https://github.com/xetus-oss/docker-archiva/blob/v2-legacy/Dockerfile)| Legacy versions of this image         |
 
@@ -35,7 +35,7 @@ An Apache Archiva image for simple standalone deployments.
 
 # About Apache Archiva
 
-[Apache Archiva](https://archiva.apache.org/) is maven-compatible artifact repository that is reasonably configurable and quite stable. 
+[Apache Archiva](https://archiva.apache.org/) is maven-compatible artifact repository that is reasonably configurable and quite stable.
 
 # About `xetusoss/archiva`
 
@@ -59,7 +59,7 @@ docker run --name archiva -p 8080:8080 xetusoss/archiva
 
 ## Deploying with `docker-compose`
 
-The example below shows how to deploy archiva with a separate data volume using docker-compose. 
+The example below shows how to deploy archiva with a separate data volume using docker-compose.
 
 ```yaml
 version: '3.4'
@@ -111,7 +111,7 @@ Allow fine-tuned control over the JVM environment that archiva runs in, or set t
 
 ## `JETTY_CONFIG_PATH`
 
-If the container-managed `jetty.xml` file is not flexible enough for your deployment scenario, the `JETTY_CONFIG_PATH` environment variable can be used to manually specify a configuration file. 
+If the container-managed `jetty.xml` file is not flexible enough for your deployment scenario, the `JETTY_CONFIG_PATH` environment variable can be used to manually specify a configuration file.
 
 # Adding CA certificates
 

--- a/files/resource-retriever.sh
+++ b/files/resource-retriever.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 BUILD_SNAPSHOT_RELEASE=${BUILD_SNAPSHOT_RELEASE:-false}
 if [ $BUILD_SNAPSHOT_RELEASE = true ]
 then
-  ARCHIVA_SNAPSHOTS_BASE="https://archiva-repository.apache.org/archiva/repository/snapshots/org/apache/archiva/archiva-jetty/2.2.6-SNAPSHOT/"
+  ARCHIVA_SNAPSHOTS_BASE="https://archiva-repository.apache.org/archiva/repository/snapshots/org/apache/archiva/archiva-jetty/3.0.0-SNAPSHOT/"
   BUILD_NO=$(curl -s "${ARCHIVA_SNAPSHOTS_BASE}maven-metadata.xml" |\
     grep buildNumber | cut -f2 -d'>' | cut -f1 -d'<')
 
@@ -21,11 +21,11 @@ then
 
   ARCHIVA_RELEASE_URL=${ARCHIVA_SNAPSHOTS_BASE}${FILE_NAME}
   ARCHIVA_RELEASE_MD5SUM=${MD5SUM}
-else 
+else
   #
   # Archiva binary parameters
   #
-  ARCHIVA_RELEASE_VERSION=2.2.8
+  ARCHIVA_RELEASE_VERSION=2.2.9
   ARCHIVA_RELEASE_URL=${ARCHIVA_RELEASE_URL:-https://downloads.apache.org/archiva/${ARCHIVA_RELEASE_VERSION}/binaries/apache-archiva-${ARCHIVA_RELEASE_VERSION}-bin.tar.gz}
   ARCHIVA_RELEASE_SHA512=$(curl "${ARCHIVA_RELEASE_URL}.sha512" | cut -f1 -d' ')
 fi


### PR DESCRIPTION
On 9th of October 2022, version 2.2.9 was released. It's a bugfix/security fix release. See [release notes](http://archiva.apache.org/docs/2.2.9/release-notes.html)

My IDE has whitespace-auto-trim at the end of the line enabled, I hope that's not a problem.