### PR TITLE
Migrate to eclipse-temurin:8-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM eclipse-temurin:8-jdk-alpine
+FROM eclipse-temurin:11-jdk
 MAINTAINER Xetus OSS <xetusoss@xetus.com>
 
 # Add the archiva user and group with a specific UID/GUI to ensure
 RUN addgroup --gid 1000 archiva &&\
 	adduser --system -u 1000 -G archiva archiva &&\
-	apk add bash curl
+ 	apt update &&\
+	apt install bash curl
 
 # Set archiva-base as the root directory we will symlink out of.
 ENV ARCHIVA_HOME /archiva

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Xetus OSS <xetusoss@xetus.com>
 
 # Add the archiva user and group with a specific UID/GUI to ensure
 RUN addgroup --gid 1000 archiva &&\
-	adduser --system -u 1000 -G archiva archiva &&\
+	adduser --system -u 1000 --gid 1000 archiva &&\
  	apt update &&\
 	apt install bash curl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:8-jdk
 MAINTAINER Xetus OSS <xetusoss@xetus.com>
 
 # Add the archiva user and group with a specific UID/GUI to ensure

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -54,4 +54,4 @@ chown -R archiva:archiva $ARCHIVA_BASE $TEMPLATE_ROOT
 # certs to it, if necessary
 #
 chown archiva:archiva ${JAVA_HOME}/jre/lib/security/cacerts
-chmod u+w ${JAVA_HOME}/jre/lib/security/cacerts
+chmod u+w ${JAVA_HOME}/lib/security/cacerts

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -53,5 +53,5 @@ chown -R archiva:archiva $ARCHIVA_BASE $TEMPLATE_ROOT
 # Make the cacerts owned by archiva so we can add
 # certs to it, if necessary
 #
-chown archiva:archiva ${JAVA_HOME}/lib/security/cacerts
-chmod u+w ${JAVA_HOME}/lib/security/cacerts
+chown archiva:archiva ${JAVA_HOME}/jre/lib/security/cacerts
+chmod u+w ${JAVA_HOME}/jre/lib/security/cacerts

--- a/files/setup.sh
+++ b/files/setup.sh
@@ -53,5 +53,5 @@ chown -R archiva:archiva $ARCHIVA_BASE $TEMPLATE_ROOT
 # Make the cacerts owned by archiva so we can add
 # certs to it, if necessary
 #
-chown archiva:archiva ${JAVA_HOME}/jre/lib/security/cacerts
+chown archiva:archiva ${JAVA_HOME}/lib/security/cacerts
 chmod u+w ${JAVA_HOME}/lib/security/cacerts


### PR DESCRIPTION
Change to ubuntu based image which supports windows/amd64, linux/amd64, linix/armv/v7, linux/arm64/v8, linux/ppc64le